### PR TITLE
fix: Github secret not set

### DIFF
--- a/.github/workflows/pr-testing.yml
+++ b/.github/workflows/pr-testing.yml
@@ -91,6 +91,7 @@ jobs:
       PYTHONPATH: src/
       SHA: ${{ github.sha }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
     steps:


### PR DESCRIPTION
Fix for

```
Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
Traceback (most recent call last):
  File "/home/runner/work/keithfembot/keithfembot/.venv/lib/python3.8/site-packages/coveralls/cli.py", line 61, in main
    coverallz = Coveralls(token_required,
  File "/home/runner/work/keithfembot/keithfembot/.venv/lib/python3.8/site-packages/coveralls/api.py", line 47, in __init__
    self.ensure_token()
  File "/home/runner/work/keithfembot/keithfembot/.venv/lib/python3.8/site-packages/coveralls/api.py", line 54, in ensure_token
    raise CoverallsException(
coveralls.exception.CoverallsException: Running on Github Actions but GITHUB_TOKEN is not set. Add "env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}" to your step config.
```