### PR TITLE
Remove /togo command.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -561,7 +561,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "b60d796ec15b33e03a21593ad7758202b0c9f9ec36e9c1cc20638b19daf44428"
+content-hash = "881a3b9ba10f9a8634cafae8e6d531fd31e26d08860f5ba6b276055fc5e77e4c"
 
 [metadata.files]
 apscheduler = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ setuptools = "^65.6.3"
 distribute = "^0.7.3"
 pip = "^22.3.1"
 pipenv = "^2022.11.30"
+pytest = "^7.2.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/src/keithfembot.py
+++ b/src/keithfembot.py
@@ -145,15 +145,6 @@ class KeithFemBotCommands:
             "[https://www.paypal.me/keithfem]",
         )
 
-    def togo(self, update, context):
-        """Displays Keith togo link"""
-        togo_text = (
-            "Keith Togo 🇹🇬\n"
-            "Thursday - Sunday 15-20h\n"
-            "Check https://t.me/keithtogo for more details\n"
-        )
-        self._send(update, context, togo_text)
-
     def help(self, update, context):
         """Help usage."""
         help_text = (
@@ -163,7 +154,6 @@ class KeithFemBotCommands:
             "`/today`: displays the schedule for today.\n"
             "`/tomorrow`: displays the schedule for tomorrow.\n"
             "`/week`: displays the shows for the week.\n"
-            "`/togo`: info to order drinks.\n"
             "`/gibberish`: some gibberish.\n"
             "`/joke`: KeithF'em BotMeister, tell me a joke.\n"
             "`/donate`: donate to Keith F'em.\n"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -32,20 +32,6 @@ def test_donate():
         mock_send.assert_called_once_with(None, None, msg)
 
 
-def test_togo():
-
-    msg = (
-        "Keith Togo 🇹🇬\n"
-        "Thursday - Sunday 15-20h\n"
-        "Check https://t.me/keithtogo for more details\n"
-    )
-
-    with patch.object(KeithFemBotCommands, "_send", return_value=None) as mock_send:
-        KFBC = KeithFemBotCommands()
-        KFBC.togo(update=None, context=None)
-        mock_send.assert_called_once_with(None, None, msg)
-
-
 def test_help():
 
     msg = (

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -41,7 +41,6 @@ def test_help():
         "`/today`: displays the schedule for today.\n"
         "`/tomorrow`: displays the schedule for tomorrow.\n"
         "`/week`: displays the shows for the week.\n"
-        "`/togo`: info to order drinks.\n"
         "`/gibberish`: some gibberish.\n"
         "`/joke`: KeithF'em BotMeister, tell me a joke.\n"
         "`/donate`: donate to Keith F'em.\n"


### PR DESCRIPTION
No longer needed. Was meant for the pandemic.