### PR TITLE
fix: date in class should be updated

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -258,9 +258,14 @@ class Today(DayCommand):
 
     def __init__(self, http_client, service_url=None):
         super().__init__(http_client, service_url)
+        self.no_shows_message = "No shows are scheduled for today 🤷."
+
+    def __call__(
+        self, update: Union[Update, None], context: Union[CallbackContext, None]
+    ) -> str:
         today = dt.date.today()
         self.on_day = calendar.day_name[today.weekday()].lower()
-        self.no_shows_message = "No shows are scheduled for today 🤷."
+        return super().__call__(update, context)
 
 
 class Tomorrow(DayCommand):
@@ -268,12 +273,17 @@ class Tomorrow(DayCommand):
 
     def __init__(self, http_client, service_url=None):
         super().__init__(http_client, service_url)
+        self.no_shows_message = "No shows are scheduled for tomorrow 🤷."
+
+    def __call__(
+        self, update: Union[Update, None], context: Union[CallbackContext, None]
+    ) -> str:
         tomorrow = dt.date.today() + dt.timedelta(days=1)
         self.on_day = calendar.day_name[tomorrow.weekday()].lower()
         # if tomorrow is monday, fetches 'nextmonday' on the array
         if self.on_day.lower() == calendar.day_name[calendar.firstweekday()].lower():
             self.on_day = "next" + self.on_day
-        self.no_shows_message = "No shows are scheduled for tomorrow 🤷."
+        return super().__call__(update, context)
 
 
 class Week(Command):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,5 @@
+import calendar
+import datetime as dt
 from unittest.mock import patch
 
 import pytest
@@ -18,9 +20,6 @@ from commands import (
     Week,
 )
 from exceptions import HTTPError
-
-import datetime as dt
-import calendar
 
 
 class TestCommandsWithoutDependencies:
@@ -389,7 +388,7 @@ class TestCommandsWithDependencies:
             today_command = Today(http_client=requests)
 
             assert frozen_datetime() == tuesday_dt
-            assert calendar.day_name[tuesday_dt.weekday()].lower() == 'tuesday'
+            assert calendar.day_name[tuesday_dt.weekday()].lower() == "tuesday"
 
             with patch.object(Command, "send", return_value=None) as mock_send:
                 with patch("requests.get") as patched_get:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -19,6 +19,9 @@ from commands import (
 )
 from exceptions import HTTPError
 
+import datetime as dt
+import calendar
+
 
 class TestCommandsWithoutDependencies:
     """Methods without external dependencies"""
@@ -364,3 +367,50 @@ class TestCommandsWithDependencies:
                 mock_send.assert_called_once_with(None, None, msg)
 
         assert msg == expected
+
+    def test_fix_today_when_day_changes(self, response_week_info_with_empty_days):
+        expected_for_tuesday = (
+            "No shows are scheduled for today 🤷.\n"
+            "Check the weekly schedule with /week command."
+        )
+
+        expected_for_wednesday = (
+            "Shows for Wednesday _🇩🇪 time!_\n"
+            "(15:00 - 17:00) - *Actual Figures*\n"
+            "(18:00 - 20:00) - *Kraut Kontrol*\n"
+            "(20:00 - 23:00) - *The Broth*\n"
+            "(23:00 - 23:25) - *Hearse Case Scenario - Die Bestatterinnen*\n"
+        )
+
+        tuesday_dt = dt.datetime(year=2020, month=12, day=29)  # Tuesday
+        wednesday_dt = dt.datetime(year=2020, month=12, day=30)  # Wednesday
+
+        with freeze_time(tuesday_dt) as frozen_datetime:
+            today_command = Today(http_client=requests)
+
+            assert frozen_datetime() == tuesday_dt
+            assert calendar.day_name[tuesday_dt.weekday()].lower() == 'tuesday'
+
+            with patch.object(Command, "send", return_value=None) as mock_send:
+                with patch("requests.get") as patched_get:
+                    patched_get.return_value = response_week_info_with_empty_days
+                    msg = today_command(update=None, context=None)
+
+                    patched_get.assert_called_once()
+                    mock_send.assert_called_once_with(None, None, msg)
+
+            assert msg == expected_for_tuesday
+
+            frozen_datetime.move_to(wednesday_dt)
+
+            assert frozen_datetime() == wednesday_dt
+
+            with patch.object(Command, "send", return_value=None) as mock_send:
+                with patch("requests.get") as patched_get:
+                    patched_get.return_value = response_week_info_with_empty_days
+                    msg = today_command(update=None, context=None)
+
+                    patched_get.assert_called_once()
+                    mock_send.assert_called_once_with(None, None, msg)
+
+            assert msg == expected_for_wednesday


### PR DESCRIPTION
Bug: When `/today` or `/tomorrow` was being called, the day (today) used was the day when the application was deployed.

Fix: the day was being created on the constructors. They had to be updated on every call.
